### PR TITLE
Cache regex to avoid recompiling on every call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
 name = "demoji"
 version = "0.0.3"
 dependencies = [
+ "once_cell",
  "regex",
 ]
 
@@ -23,6 +24,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ readme = "README.md"
 
 [dependencies]
 regex = "1.5.4"
+once_cell = "1.10.0"
 
 [profile.release]
 opt-level = 3     # Optimize for speed.
-lto = true          # Enable Link Time Optimization
-codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+lto = true        # Enable Link Time Optimization
+codegen-units = 1 # Reduce number of codegen units to increase optimizations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,14 @@
 //! ## Examples
 //!
 //! ```rust
+//! # use demoji::demoji;
 //! // Remove all emojis from this string
 //! let demojified_string = demoji("⚡hel✅🙂lo🙂");
-//! assert_eq!(demojified_string, String::from("hello"));
+//! assert_eq!(demojified_string, "hello");
 //! ```
+use once_cell::sync::Lazy;
 use regex::Regex;
+use std::borrow::Cow;
 
 /// Removes all emojis from a string **(retains chinese characters)**
 ///
@@ -27,46 +30,51 @@ use regex::Regex;
 ///
 /// # Returns
 ///
-/// * `String` - De-emojified string
+/// * `Cow<str>` - De-emojified string
+///
+/// If no emojis are found in the given string, then the original string is returned, avoiding the allocation of a new string.
 ///
 /// # Examples
 ///
 /// ```
-///
+/// # use demoji::demoji;
 /// // Remove all emojis from this string
-/// let demojified_string = demoji("⚡hel✅🙂lo🙂")
+/// let demojified_string = demoji("⚡hel✅🙂lo🙂");
 /// assert_eq!(demojified_string, String::from("hello"));
 /// // Output: `hello`
 /// ```
-pub fn demoji(string: &str) -> String {
-    let regex = Regex::new(concat!(
-        "[",
-        "\u{01F600}-\u{01F64F}", // emoticons
-        "\u{01F300}-\u{01F5FF}", // symbols & pictographs
-        "\u{01F680}-\u{01F6FF}", // transport & map symbols
-        "\u{01F1E0}-\u{01F1FF}", // flags (iOS)
-        "\u{002702}-\u{0027B0}",
-        "\u{0024C2}-\u{01F251}",
-        "]+",
-    ))
-    .unwrap();
+pub fn demoji(string: &str) -> Cow<'_, str> {
+    // cache regex to avoid re-compiling it every call
+    static REGEX: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(concat!(
+            "[",
+            "\u{01F600}-\u{01F64F}", // emoticons
+            "\u{01F300}-\u{01F5FF}", // symbols & pictographs
+            "\u{01F680}-\u{01F6FF}", // transport & map symbols
+            "\u{01F1E0}-\u{01F1FF}", // flags (iOS)
+            "\u{002702}-\u{0027B0}",
+            "\u{0024C2}-\u{01F251}",
+            "]+",
+        ))
+        .unwrap()
+    });
 
-    regex.replace_all(&string, "").to_string()
+    REGEX.replace_all(&string, "")
 }
 
 /// Demojify `String` and `&str`
 pub trait Demoji {
-    fn demojify(&self) -> String;
+    fn demojify(&self) -> Cow<'_, str>;
 }
 
 impl Demoji for &str {
-    fn demojify(&self) -> String {
+    fn demojify(&self) -> Cow<'_, str> {
         demoji(self)
     }
 }
 
 impl Demoji for String {
-    fn demojify(&self) -> String {
+    fn demojify(&self) -> Cow<'_, str> {
         demoji(&self)
     }
 }


### PR DESCRIPTION
This PR caches the emoji regex in a [`Lazy`](https://docs.rs/once_cell/latest/once_cell/sync/struct.Lazy.html), which means that, instead of re-compiling the regex every time this function is called (which can be quite expensive), it now does this only once on the first call, and then reuses the regex in future calls. Recompiling the regex all the time is also mentioned as an anti-pattern [in the docs of the Regex crate](https://docs.rs/regex/latest/regex/index.html#example-avoid-compiling-the-same-regex-in-a-loop).

Given that this crate aims to be *fast*, I've also changed the return type to `Cow<str>`. This gives the user more flexibility, and avoids an unnecessary string allocation if the input string is not changed.

Also, it seems that the tests didn't compile, so I fixed those as well.